### PR TITLE
Initial build pipeline

### DIFF
--- a/custom_typings/dom5.d.ts
+++ b/custom_typings/dom5.d.ts
@@ -1,0 +1,61 @@
+// TODO(rictic): upstream this to dom5 itself.
+
+declare module 'dom5' {
+  export interface Node {
+    nodeName: string;
+    tagName: string;
+    childNodes: Node[];
+    parentNode: Node;
+    attrs: Attr[];
+    value?: string;
+    data?: string;
+    __location?: {
+      start: number;
+    }
+  }
+  export interface Attr {
+    name: string;
+    value: string;
+  }
+  interface ParseOptions {
+    locationInfo: boolean;
+  }
+
+  export function parse(text: string, opts?: ParseOptions):Node;
+  export function parseFragment(text: string, opts?: ParseOptions):Node;
+
+  export function serialize(node: Node): string;
+
+  export type Predicate = (n:Node) => boolean;
+  export function query(root: Node, predicate: Predicate):Node;
+  export function queryAll(root: Node, predicate: Predicate):Node[];
+  export function nodeWalk(node: Node, predicate: Predicate):Node;
+  export function nodeWalkAll(node: Node, predicate: Predicate):Node[];
+  export function nodeWalkAllPrior(node: Node, predicate: Predicate):Node[];
+  export function treeMap(node: Node, walker:(node: Node)=>void):void;
+  export function getAttribute(node: Node, attrName: string): string;
+  export function setAttribute(node: Node, attrName: string, attrValue: string);
+  export function removeAttribute(node: Node, attrName: string): string;
+  export function getTextContent(node: Node): string;
+  export function setTextContent(node: Node, string: string): void;
+  export function append(parent: Node, newNode: Node): void;
+  export function remove(willBeRemoved: Node): void;
+  export function replace(current: Node, replacement: Node): void;
+
+  export var isCommentNode: Predicate;
+  interface PredicateCombinators {
+    hasTagName(name: string):Predicate;
+    hasAttr(name: string): Predicate;
+    hasAttrValue(name: string, value: string): Predicate;
+    NOT(pred: Predicate):Predicate;
+    AND(...preds: Predicate[]):Predicate;
+    OR(...preds: Predicate[]):Predicate;
+  }
+  export var predicates: PredicateCombinators;
+
+  interface Constructors {
+    element(tagName: string): Node;
+    text(content: string): Node;
+  }
+  export var constructors: Constructors;
+}

--- a/custom_typings/hydrolysis.d.ts
+++ b/custom_typings/hydrolysis.d.ts
@@ -1,0 +1,43 @@
+declare module 'hydrolysis' {
+  interface Options {
+    filter?: (path: string) => boolean;
+  }
+  interface Element {
+    is: string;
+    contentHref: string;
+    desc?: string;
+  }
+  interface Behavior {
+    is: string;
+    contentHref: string;
+    desc?: string;
+  }
+  export class Analyzer {
+    static analyze(path: string, options: Options): Promise<Analyzer>;
+    metadataTree(path: string): Promise<void>;
+    annotate(): void;
+    elements: Element[];
+    behaviors: Behavior[];
+  }
+// }
+// declare module 'hydrolysis/loader/resolver' {
+  export class Deferred<T> {
+    promise: Promise<T>;
+    resolve: (val:(T|PromiseLike<T>))=>void;
+    reject: (err:any)=>void;
+  }
+
+  /**
+   * An object that knows how to resolve resources.
+   */
+  export interface Resolver {
+    /**
+     * Attempt to resolve `deferred` with the contents the specified URL. Returns
+     * false if the Resolver is unable to resolve the URL.
+     */
+    accept(path:string, deferred:Deferred<string>):boolean;
+  }
+  class FSResolver {
+    constructor(options: any);
+  }
+}

--- a/custom_typings/node.d.ts
+++ b/custom_typings/node.d.ts
@@ -1,0 +1,151 @@
+// copied from lib.es6.d.ts
+
+declare var console: Console;
+
+interface Console {
+    assert(test?: boolean, message?: string, ...optionalParams: any[]): void;
+    clear(): void;
+    count(countTitle?: string): void;
+    debug(message?: string, ...optionalParams: any[]): void;
+    dir(value?: any, ...optionalParams: any[]): void;
+    dirxml(value: any): void;
+    error(message?: any, ...optionalParams: any[]): void;
+    group(groupTitle?: string): void;
+    groupCollapsed(groupTitle?: string): void;
+    groupEnd(): void;
+    info(message?: any, ...optionalParams: any[]): void;
+    log(message?: any, ...optionalParams: any[]): void;
+    // msIsIndependentlyComposed(element: Element): boolean;
+    profile(reportName?: string): void;
+    profileEnd(): void;
+    // select(element: Element): void;
+    time(timerName?: string): void;
+    timeEnd(timerName?: string): void;
+    trace(message?: any, ...optionalParams: any[]): void;
+    warn(message?: any, ...optionalParams: any[]): void;
+}
+
+declare var Console: {
+    prototype: Console;
+    new(): Console;
+}
+
+declare module Intl {
+    interface CollatorOptions {
+        usage?: string;
+        localeMatcher?: string;
+        numeric?: boolean;
+        caseFirst?: string;
+        sensitivity?: string;
+        ignorePunctuation?: boolean;
+    }
+
+    interface ResolvedCollatorOptions {
+        locale: string;
+        usage: string;
+        sensitivity: string;
+        ignorePunctuation: boolean;
+        collation: string;
+        caseFirst: string;
+        numeric: boolean;
+    }
+
+    interface Collator {
+        compare(x: string, y: string): number;
+        resolvedOptions(): ResolvedCollatorOptions;
+    }
+    var Collator: {
+        new (locales?: string[], options?: CollatorOptions): Collator;
+        new (locale?: string, options?: CollatorOptions): Collator;
+        (locales?: string[], options?: CollatorOptions): Collator;
+        (locale?: string, options?: CollatorOptions): Collator;
+        supportedLocalesOf(locales: string[], options?: CollatorOptions): string[];
+        supportedLocalesOf(locale: string, options?: CollatorOptions): string[];
+    }
+
+    interface NumberFormatOptions {
+        localeMatcher?: string;
+        style?: string;
+        currency?: string;
+        currencyDisplay?: string;
+        useGrouping?: boolean;
+        minimumIntegerDigits?: number;
+        minimumFractionDigits?: number;
+        maximumFractionDigits?: number;
+        minimumSignificantDigits?: number;
+        maximumSignificantDigits?: number;
+    }
+
+    interface ResolvedNumberFormatOptions {
+        locale: string;
+        numberingSystem: string;
+        style: string;
+        currency?: string;
+        currencyDisplay?: string;
+        minimumIntegerDigits: number;
+        minimumFractionDigits: number;
+        maximumFractionDigits: number;
+        minimumSignificantDigits?: number;
+        maximumSignificantDigits?: number;
+        useGrouping: boolean;
+    }
+
+    interface NumberFormat {
+        format(value: number): string;
+        resolvedOptions(): ResolvedNumberFormatOptions;
+    }
+    var NumberFormat: {
+        new (locales?: string[], options?: NumberFormatOptions): NumberFormat;
+        new (locale?: string, options?: NumberFormatOptions): NumberFormat;
+        (locales?: string[], options?: NumberFormatOptions): NumberFormat;
+        (locale?: string, options?: NumberFormatOptions): NumberFormat;
+        supportedLocalesOf(locales: string[], options?: NumberFormatOptions): string[];
+        supportedLocalesOf(locale: string, options?: NumberFormatOptions): string[];
+    }
+
+    interface DateTimeFormatOptions {
+        localeMatcher?: string;
+        weekday?: string;
+        era?: string;
+        year?: string;
+        month?: string;
+        day?: string;
+        hour?: string;
+        minute?: string;
+        second?: string;
+        timeZoneName?: string;
+        formatMatcher?: string;
+        hour12?: boolean;
+        timeZone?: string;
+    }
+
+    interface ResolvedDateTimeFormatOptions {
+        locale: string;
+        calendar: string;
+        numberingSystem: string;
+        timeZone: string;
+        hour12?: boolean;
+        weekday?: string;
+        era?: string;
+        year?: string;
+        month?: string;
+        day?: string;
+        hour?: string;
+        minute?: string;
+        second?: string;
+        timeZoneName?: string;
+    }
+
+    interface DateTimeFormat {
+        format(date?: Date | number): string;
+        resolvedOptions(): ResolvedDateTimeFormatOptions;
+    }
+    var DateTimeFormat: {
+        new (locales?: string[], options?: DateTimeFormatOptions): DateTimeFormat;
+        new (locale?: string, options?: DateTimeFormatOptions): DateTimeFormat;
+        (locales?: string[], options?: DateTimeFormatOptions): DateTimeFormat;
+        (locale?: string, options?: DateTimeFormatOptions): DateTimeFormat;
+        supportedLocalesOf(locales: string[], options?: DateTimeFormatOptions): string[];
+        supportedLocalesOf(locale: string, options?: DateTimeFormatOptions): string[];
+    }
+}

--- a/custom_typings/yeoman-environment.d.ts
+++ b/custom_typings/yeoman-environment.d.ts
@@ -1,0 +1,8 @@
+declare module 'yeoman-environment' {
+  class YeomanEnvironment {
+    register(library: any, target: string);
+    run(target: string, options: any, done: Function);
+  }
+
+  export = YeomanEnvironment;
+}

--- a/package.json
+++ b/package.json
@@ -16,8 +16,15 @@
   "dependencies": {
     "command-line-commands": "^0.1.2",
     "generator-polymer-init": "^0.0.1",
+    "gulp-crisper": "^1.0.0",
+    "gulp-if": "^2.0.0",
+    "gulp-vulcanize": "^6.1.0",
+    "hydrolysis": "^1.23.3",
+    "liftoff": "^2.2.1",
     "polylint": "^2.10.0",
     "polyserve": "^0.7.1",
+    "uglify-js": "^2.6.2",
+    "vinyl-fs": "^2.4.3",
     "web-component-tester": "^4.2.0",
     "yeoman-environment": "^1.5.2"
   },

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import * as gulp from 'gulp';
+import * as gulpif from 'gulp-if';
+import * as gutil from 'gulp-util';
+import * as minimatch from 'minimatch';
+import File = require('vinyl');
+import * as vfs from 'vinyl-fs';
+
+import {HtmlProject} from './html-project';
+import {StreamResolver} from './stream-resolver';
+
+const findConfig = require('liftoff/lib/find_config');
+const vulcanize = require('gulp-vulcanize');
+
+export function build(entrypoint, sources): Promise<any> {
+  return new Promise<any>((resolve, _) => {
+
+    entrypoint = entrypoint || 'index.html';
+    sources = sources || ['{src,test}/**/*'];
+    let e = [entrypoint];
+    sources = e.concat.apply(e, sources);
+
+    let gulpfilePath = findConfig({
+      searchPaths: [process.cwd()],
+      configNameSearch: 'gulpfile.js',
+    });
+    let gulpfile = gulpfilePath && require(gulpfilePath);
+    let userTransformers = gulpfile && gulpfile.transformers;
+
+    let project = new HtmlProject();
+    let splitPhase = vfs.src(sources)
+      .pipe(project.split);
+
+    let userPhase = splitPhase;
+    if (userTransformers) {
+      for (let transformer of userTransformers) {
+        userPhase = userPhase.pipe(transformer);
+      }
+    }
+    let streamResolver = new StreamResolver({
+        entrypoint: entrypoint,
+        basePath: process.cwd(),
+        root: process.cwd(),
+        redirect: 'bower_components/',
+      });
+    let joinPhase = userPhase
+      .pipe(project.rejoin)
+      .pipe(streamResolver)
+      .pipe(gulpif((file) => minimatch(file.path, entrypoint, {
+          matchBase: true,
+        }), vulcanize({
+          fsResolver: streamResolver,
+          inlineScripts: true,
+          inlineCss: true,
+          stripComments: true
+        })
+      ))
+      .pipe(gulp.dest('build'))
+      .on('finish', () => {
+        resolve(null);
+      });
+  });
+}

--- a/src/build/html-project.ts
+++ b/src/build/html-project.ts
@@ -1,0 +1,236 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import * as dom5 from 'dom5';
+import * as path from 'path';
+import {Transform} from 'stream';
+import File = require('vinyl');
+
+const pred = dom5.predicates;
+
+const extensionsForType = {
+  'text/ecmascript-6': 'js',
+  'application/javascript': 'js',
+  'text/javascript': 'js',
+  'application/x-typescript': 'ts',
+  'text/x-typescript': 'ts',
+};
+
+/**
+ * Splits and rejoins inline scripts and styles from HTML files.
+ *
+ * Use `HtmlProject.prototype.split` and `HtmlProject.prototype.rejoin` to
+ * surround processing steps that operate on the extracted resources.
+ * HtmlProject works well with gulp-if to process files based on filename.
+ */
+export class HtmlProject {
+
+  _splitFiles : Map<string, SplitFile> = new Map();
+  _parts : Map<string, SplitFile> = new Map();
+  split = new Splitter(this);
+  rejoin = new Rejoiner(this);
+
+  isSplitFile(parentPath: string): boolean {
+    return this._splitFiles.has(parentPath);
+  }
+
+  getSplitFile(parentPath: string): SplitFile {
+    let splitFile = this._splitFiles.get(parentPath);
+    if (!splitFile) {
+      splitFile = new SplitFile(parentPath);
+      this._splitFiles.set(parentPath, splitFile);
+    }
+    return splitFile;
+  }
+
+  addSplitPath(parentPath: string, childPath: string): void {
+    let splitFile = this.getSplitFile(parentPath);
+    splitFile.addPartPath(childPath);
+    this._parts.set(childPath, splitFile);
+  }
+
+  getParentFile(childPath: string): SplitFile {
+    return this._parts.get(childPath);
+  }
+
+}
+
+
+/**
+ * Represents a file that is split into multiple files.
+ */
+class SplitFile {
+  path : string;
+  parts : Map<string, string> = new Map();
+  outstandingPartCount = 0;
+  vinylFile : File = null;
+
+  constructor(path: string) {
+    this.path = path;
+  }
+
+  addPartPath(path: string): void {
+    this.parts.set(path, null);
+    this.outstandingPartCount++;
+  }
+
+  setPartContent(path: string, content: string): void {
+    console.assert(this.parts.get(path) === null);
+    console.assert(this.outstandingPartCount > 0);
+    this.parts.set(path, content);
+    this.outstandingPartCount--;
+  }
+
+  get isComplete(): boolean {
+    return this.outstandingPartCount === 0 && this.vinylFile != null;
+  }
+}
+
+/**
+ * Splits HTML files, extracting scripts and styles into separate `File`s.
+ */
+class Splitter extends Transform {
+
+  static isInlineScript = pred.AND(
+    pred.hasTagName('script'),
+    pred.NOT(pred.hasAttr('src'))
+  );
+
+  _project : HtmlProject;
+
+  constructor(project) {
+    super({objectMode: true});
+    this._project = project;
+  }
+
+  _transform(file: File, encoding: string, callback: (error?, data?) => void): void {
+    if (file.contents && file.path.endsWith('.html')) {
+      try {
+        let contents = file.contents.toString();
+        let doc = dom5.parse(contents);
+        let body = dom5.query(doc, pred.hasTagName('body'));
+        let head = dom5.query(doc, pred.hasTagName('head'));
+        let scriptTags = dom5.queryAll(doc, Splitter.isInlineScript);
+        let styleTags = dom5.queryAll(doc, pred.hasTagName('style'));
+
+        let scripts = [];
+        let styles = [];
+
+        for (let i = 0; i < scriptTags.length; i++) {
+          let scriptTag = scriptTags[i];
+          let source = dom5.getTextContent(scriptTag);
+          let typeAtribute = dom5.getAttribute(scriptTag, 'type');
+          let extension = typeAtribute && extensionsForType[typeAtribute] || 'js';
+          let childFilename = `${path.basename(file.path)}_script_${i}.${extension}`;
+          let childPath = `${path.dirname(file.path)}/${childFilename}`;
+          scriptTag.childNodes = [];
+          dom5.setAttribute(scriptTag, 'src', childFilename);
+          let scriptFile = new File({
+        		cwd: file.cwd,
+        		base: file.base,
+        		path: childPath,
+        		contents: new Buffer(source),
+        	});
+          this._project.addSplitPath(file.path, childPath);
+          this.push(scriptFile);
+        }
+
+        let splitContents = dom5.serialize(doc);
+        let newFile = new File({
+          cwd: file.cwd,
+          base: file.base,
+          path: file.path,
+          contents: new Buffer(splitContents),
+        });
+        callback(null, newFile);
+      } catch (e) {
+        callback(e, null);
+      }
+    } else {
+      callback(null, file);
+    }
+  }
+}
+
+/**
+ * Joins HTML files split by `Splitter`.
+ */
+class Rejoiner extends Transform {
+
+  static isExternalScript = pred.AND(
+    pred.hasTagName('script'),
+    pred.hasAttr('src')
+  );
+
+  _project : HtmlProject;
+
+  constructor(project) {
+    super({objectMode: true});
+    this._project = project;
+  }
+
+  _transform(file: File, encoding: string, callback: (error?, data?) => void): void {
+    if (this._project.isSplitFile(file.path)) {
+      // this is a parent file
+      let splitFile = this._project.getSplitFile(file.path);
+      splitFile.vinylFile = file;
+      if (splitFile.isComplete) {
+        callback(null, this._rejoin(splitFile));
+      } else {
+        splitFile.vinylFile = file;
+        callback();
+      }
+    } else {
+      let parentFile = this._project.getParentFile(file.path);
+      if (parentFile) {
+        // this is a child file
+        parentFile.setPartContent(file.path, file.contents.toString());
+        if (parentFile.isComplete) {
+          callback(null, this._rejoin(parentFile));
+        } else {
+          callback();
+        }
+      } else {
+        callback(null, file);
+      }
+    }
+  }
+
+  _rejoin(splitFile: SplitFile) {
+    let file = splitFile.vinylFile;
+    let contents = file.contents.toString();
+    let doc = dom5.parse(contents);
+    let body = dom5.query(doc, pred.hasTagName('body'));
+    let head = dom5.query(doc, pred.hasTagName('head'));
+    let scriptTags = dom5.queryAll(doc, Rejoiner.isExternalScript);
+    let styleTags = dom5.queryAll(doc, pred.hasTagName('style'));
+
+    for (let i = 0; i < scriptTags.length; i++) {
+      let scriptTag = scriptTags[i];
+      let srcAttribute = dom5.getAttribute(scriptTag, 'src');
+      let scriptPath = path.resolve(path.dirname(splitFile.path), srcAttribute);
+      if (splitFile.parts.has(scriptPath)) {
+        let scriptSource = splitFile.parts.get(scriptPath);
+        dom5.setTextContent(scriptTag, scriptSource);
+        dom5.removeAttribute(scriptTag, 'src');
+      }
+    }
+
+    let joinedContents = dom5.serialize(doc);
+
+    return new File({
+      cwd: file.cwd,
+      base: file.base,
+      path: file.path,
+      contents: new Buffer(joinedContents),
+    });
+
+  }
+}

--- a/src/build/stream-resolver.ts
+++ b/src/build/stream-resolver.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import * as fs from 'fs';
+import {Resolver, Deferred, FSResolver} from 'hydrolysis';
+import * as minimatch from 'minimatch';
+import * as path from 'path';
+import {Transform} from 'stream';
+import File = require('vinyl');
+import * as url from 'url';
+
+export interface Config {
+  entrypoint?: string;
+  /**
+   * Hostname to match for absolute urls.
+   * Matches "/" by default
+   */
+  host?: string;
+  /**
+   * Prefix directory for components in url. Defaults to "/".
+   */
+  basePath?: string;
+  /**
+   * Filesystem root to search. Defaults to the current working directory.
+   */
+  root?: string;
+  /**
+   * Where to redirect lookups to siblings.
+   */
+  redirect?: string;
+}
+
+export class StreamResolver extends Transform /* implements Resolver*/ {
+
+  _files = new Map<string, File>();
+  _deferreds = new Map<string, Deferred<string>>();
+  config: Config;
+
+  constructor(config: Config) {
+    super({objectMode: true});
+    this.config = config || {};
+  }
+
+  _transform(file: File, encoding: string, callback: (error?, data?) => void): void {
+    let isEntrypoint = minimatch(file.path, this.config.entrypoint, {
+      matchBase: true,
+    });
+    if (isEntrypoint) {
+      this._files.set(file.path, file);
+      callback(null, file);
+      return;
+    }
+    let deferred = this._deferreds.get(file.path);
+    if (deferred) {
+      this._deferreds.delete(file.path);
+      deferred.resolve(file.contents.toString());
+    } else {
+      this._files.set(file.path, file);
+    }
+    callback(null, null);
+  }
+
+  accept(uri: string, deferred: Deferred<string>): boolean {
+    var parsed = url.parse(uri);
+    var host = this.config.host;
+    var base = this.config.basePath && decodeURIComponent(this.config.basePath);
+    var root = this.config.root && path.normalize(this.config.root);
+    var redirect = this.config.redirect;
+
+    var local: string;
+
+    if (!parsed.hostname || parsed.hostname === host) {
+      local = parsed.pathname;
+    }
+    if (local) {
+      // un-escape HTML escapes
+      local = decodeURIComponent(local);
+
+      if (base) {
+        local = path.relative(base, local);
+      }
+      if (root) {
+        local = path.join(root, local);
+      }
+
+      if (redirect && isSiblingOrAunt(root, local)) {
+        local = redirectSibling(root, local, redirect);
+        getFile(local, deferred);
+        return true;
+      }
+
+      let file : File = this._files.get(local);
+      if (file) {
+        deferred.resolve(file.contents.toString());
+      } else {
+        this._deferreds.set(local, deferred);
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  complete() {
+    for (let deferred in this._deferreds.values) {
+      (<Deferred<string>><any>deferred).reject(null);
+    }
+  }
+}
+
+function getFile(filePath: string, deferred: Deferred<string>) {
+  fs.readFile(filePath, 'utf-8', function(err, content) {
+    if (err) {
+      console.log("ERROR finding " + filePath);
+      deferred.reject(err);
+    } else {
+      deferred.resolve(content);
+    }
+  });
+}
+
+/**
+ * Returns true if `patha` is a sibling or aunt of `pathb`.
+ */
+function isSiblingOrAunt(patha: string, pathb: string) {
+  var parent = path.dirname(patha);
+  if (pathb.indexOf(patha) === -1 && pathb.indexOf(parent) === 0) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Change `localPath` from a sibling of `basePath` to be a child of
+ * `basePath` joined with `redirect`.
+ */
+function redirectSibling(basePath: string, localPath: string, redirect: string) {
+  var parent = path.dirname(basePath);
+  var redirected = path.join(basePath, redirect, localPath.slice(parent.length));
+  return redirected;
+}

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -8,23 +8,30 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
+import {ArgDescriptor} from 'command-line-args';
+import {CLI} from 'command-line-commands';
+
 import {Command} from './command';
+import {build} from '../build/build';
 
-// not ES modules compatible
-const YeomanEnvironment = require('yeoman-environment');
+export class BuildCommand implements Command {
+  name = 'build';
 
-export class InitCommand implements Command {
-  name = 'init';
+  description = 'Builds an application-style project';
 
-  description = 'Initializes a Polymer project';
-
-  args = [];
+  args = [
+    {
+      name: 'entrypoint',
+      description: 'The entrypoint file to build',
+      defaultOption: true,
+    },
+    {
+      name: 'sources',
+      description: 'The sources file to build',
+    }
+  ];
 
   run(options): Promise<any> {
-    return new Promise((resolve, reject) => {
-      let env = new YeomanEnvironment();
-      env.register(require.resolve('generator-polymer-init'), 'polymer-init:app');
-      env.run('polymer-init', {}, () => resolve());
-    });
+    return build(options.entrypoint, options.sources);
   }
 }

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -1,5 +1,16 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
 import {Command} from './command';
-import * as polylint from 'polylint/lib/cli';
+
+const polylint = require('polylint/lib/cli');
 
 export class LintCommand implements Command {
   name = 'lint';

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,5 +1,16 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
 import {Command} from './command';
-import {startServer} from 'polyserve';
+
+const startServer = require('polyserve').startServer;
 
 export class ServeCommand implements Command {
   name = 'serve';

--- a/src/polytool.ts
+++ b/src/polytool.ts
@@ -1,6 +1,15 @@
-'use strict';
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
 
 import * as commandLineCommands from 'command-line-commands';
+import {BuildCommand} from './commands/build';
 import {HelpCommand} from './commands/help';
 import {InitCommand} from './commands/init';
 import {LintCommand} from './commands/lint';
@@ -15,6 +24,7 @@ export class Polytool {
   cli : commandLineCommands.CLI;
 
   constructor() {
+    this.addCommand(new BuildCommand());
     this.addCommand(new HelpCommand(this.commands));
     this.addCommand(new InitCommand());
     this.addCommand(new LintCommand());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "declaration": false,
     "noImplicitAny": false,
     "removeComments": false,
-    "noLib": false,
+    "noLib": true,
     "preserveConstEnums": true,
     "suppressImplicitAnyIndexErrors": true,
     "outDir": "lib"
@@ -19,9 +19,14 @@
     "!node_modules/**",
     "custom_typings/*.d.ts",
     "typings/main/*.d.ts",
-    "typings/main.d.ts"
+    "typings/main.d.ts",
+    "node_modules/typescript/lib/lib.core.es6.d.ts"
   ],
   "files": [
+    "src/build/build.ts",
+    "src/build/html-project.ts",
+    "src/build/stream-resolver.ts",
+    "src/commands/build.ts",
     "src/commands/command.ts",
     "src/commands/help.ts",
     "src/commands/init.ts",
@@ -31,8 +36,13 @@
     "src/polytool.ts",
     "custom_typings/command-line-args.d.ts",
     "custom_typings/command-line-commands.d.ts",
+    "custom_typings/dom5.d.ts",
+    "custom_typings/hydrolysis.d.ts",
+    "custom_typings/node.d.ts",
     "custom_typings/web-component-tester.d.ts",
-    "typings/main.d.ts"
+    "custom_typings/yeoman-environment.d.ts",
+    "typings/main.d.ts",
+    "node_modules/typescript/lib/lib.core.es6.d.ts"
   ],
   "atom": {
     "rewriteTsconfig": true


### PR DESCRIPTION
This adds a generic build pipeline to polytool.

 * Builds can be extended by the project gulpfile by exporting a `transforms` property.
 * HTML files are split similar to crisper, but style should also be split (WIP), and they are recombined by default. script and style tags are not moved like in cripser.
 * Vulcanize reads files from the gulp stream unlike default gulp-vulcanize. This means that transformed files are passed through vulcanize. I'm uncertain how well that actually works with normal gulp-vulcanize, as it might depend on the ordering and completeness of other transform steps and whether they've written to disk yet.
* entrypoints and source globs can be specified, but there's only support for a single entrypoint right now. This needs to be expanded to multiple entrypoints, and sharding.

Future work:
  * ES6 module support: transform `<script type=module>` to an HTML import that loads an HTML file with non-module script tag.
  * polystyle support: auto-wrap external CSS in a dom-module
  * service worker / manifest type things
  * optionally run packages through the pipeline. Right now there's an escape hatch in the loader that vulcanize uses to read from disk, but piping packages through the compiler might be preferable, especially with npm and packages that have esnext fields.

The code is a bit of a mess, but I wanted to get this up for interested parties.

@robdodson @addyosmani @garlicnation