### PR TITLE
add missing typings dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "yeoman-environment": "^1.5.2"
   },
   "devDependencies": {
-    "typescript": "^1.8.10"
+    "typescript": "^1.8.10",
+    "typings": "^0.8.1"
   }
 }


### PR DESCRIPTION
`npm run init` & `npm run build` both failed to run on my machine (i don't have them installed globally). This adds them as local `devDependencies` where npm is able to find & use them via it's $PATH.

/cc @justinfagnani 