### PR TITLE
Fix busted streams

### DIFF
--- a/src/build/logger.ts
+++ b/src/build/logger.ts
@@ -22,7 +22,6 @@ export class Logger extends stream.Transform {
   }
 }
 
-// NOTE: this broke tar-fs streams, don't know why
 export class StreamLogger extends stream.Transform {
   prefix: string;
   constructor(prefix: string) {
@@ -31,5 +30,6 @@ export class StreamLogger extends stream.Transform {
   }
   _transform(buffer: Buffer, encoding: string, callback: (error?, data?) => void): void {
     console.log(this.prefix, buffer.toString('base64'));
+    callback(null, buffer);
   }
 }

--- a/src/build/streams.ts
+++ b/src/build/streams.ts
@@ -54,7 +54,7 @@ export class ForkedVinylStream extends Readable {
       this.push(file.clone({deep: true, contents: true}));
     });
     input.on('end', () => {
-      this.emit('end');
+      this.push(null);
     });
     input.on('error', (e) => {
       this.emit('error', e);


### PR DESCRIPTION
StreamLogger should call the callback

ForkedVinylStream should push `null` instead of emitting end on source
`end` event, as that may miss chunks sitting in the internal buffer.
Pushing `null` will let the buffer play out until it hits the null, when
the `end` event will emit itself.