### PR TITLE
Cleanup help behavior and output

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "chai": "^3.5.0",
     "depcheck": "^0.6.3",
     "gulp-mocha": "^2.2.0",
+    "sinon": "^1.17.4",
     "typescript": "^1.8.10",
     "typings": "^0.8.1",
     "vinyl-fs-fake": "^1.1.0",

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -19,28 +19,35 @@ export class HelpCommand implements Command {
     this.commands = commands;
   }
 
+  printGeneralUsage() {
+    console.log(`\nUsage: polytool <command>\n`);
+    console.log(`polytool supports the following commands:`);
+    for (let command of this.commands.values()) {
+      console.log(`  ${command.name}\t\t${command.description}`);
+    }
+    console.log(`\nRun \`polytool help <command>\` for help with a specific command.\n`);
+  }
+
   run(options): Promise<any> {
     return new Promise<any>((resolve, _) => {
-      if (options.command) {
-        let command = this.commands.get(options.command);
-        if (!command) {
-          console.log(`unknown command ${command}`);
-        } else {
-          let argsCli = commandLineArgs(command.args);
-          console.log(argsCli.getUsage({
-            title: `polytool ${command.name}`,
-            description: command.description,
-          }));
-        }
-      } else {
-        console.log(`polytool - The Polymer command-line tool\n`);
-        console.log(`usage: polytool <command> [<args>]\n`);
-        console.log(`polytool supports the following commands:`);
-        for (let command of this.commands.values()) {
-          console.log(`  ${command.name}\t\t${command.description}`);
-        }
-        console.log(`\nRun \`polytool help <command>\` for help on a specific command.\n`);
+      if (!options || !options.command) {
+        this.printGeneralUsage();
+        resolve(null);
+        return;
       }
+
+      let command = this.commands.get(options.command);
+      if (!command) {
+        this.printGeneralUsage();
+        resolve(null);
+        return;
+      }
+
+      let argsCli = commandLineArgs(command.args);
+      console.log(argsCli.getUsage({
+        title: `polytool ${command.name}`,
+        description: command.description,
+      }));
       resolve(null);
     });
   }

--- a/src/polytool.ts
+++ b/src/polytool.ts
@@ -44,18 +44,9 @@ export class Polytool {
   run(args) {
     this.cli = commandLineCommands(this.commandDescriptors);
     let cliCommand = this.cli.parse(args);
+    let polytoolCommand = this.commands.get(cliCommand.name || 'help');
 
-    if (!cliCommand.name) {
-      if (args[0]) {
-        console.error('unknown command', args[0]);
-      } else {
-        console.error('must specify a command');
-      }
-      process.exit(1);
-    }
-
-    const command = this.commands.get(cliCommand.name);
-    command.run(cliCommand.options).then((result) => {
+    polytoolCommand.run(cliCommand.options).then((result) => {
       // success
     }, (err) => {
       console.error('error', err);

--- a/test/commands/help_test.js
+++ b/test/commands/help_test.js
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+
+const assert = require('chai').assert;
+const Polytool = require('../../lib/polytool').Polytool;
+const sinon = require('sinon');
+
+suite('help', () => {
+
+  test('displays general help when the help command is called with no arguments', () => {
+    let polytool = new Polytool();
+    let helpCommand = polytool.commands.get('help');
+    let helpCommandSpy = sinon.spy(helpCommand, 'run');
+    polytool.run(['help']);
+    assert.isOk(helpCommandSpy.calledOnce);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [{}]);
+  });
+
+  test('displays general help when no command is called', () => {
+    let polytool = new Polytool();
+    let helpCommand = polytool.commands.get('help');
+    let helpCommandSpy = sinon.spy(helpCommand, 'run');
+    polytool.run([]);
+    assert.isOk(helpCommandSpy.calledOnce);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [undefined]);
+  });
+
+  test('displays general help when unknown command is called', () => {
+    let polytool = new Polytool();
+    let helpCommand = polytool.commands.get('help');
+    let helpCommandSpy = sinon.spy(helpCommand, 'run');
+    polytool.run(['THIS_IS_SOME_UNKNOWN_COMMAND']);
+    assert.isOk(helpCommandSpy.calledOnce);
+    assert.deepEqual(helpCommandSpy.firstCall.args, [undefined]);
+  });
+
+});


### PR DESCRIPTION
I cleaned up some of the code here and made the help output a little nicer. 

- New output (a few small changes here to improve readability)
- no command now outputs help instead of failing (see tests)
- unknown command now outputs help instead of failing (see tests)

<img width="840" alt="screen shot 2016-05-09 at 1 09 41 pm" src="https://cloud.githubusercontent.com/assets/622227/15126542/563fc394-15e7-11e6-9be8-ae786ac35149.png">

CR @justinfagnani 