### PR TITLE
Removes unused minimatch dependency, fixes broken tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "hydrolysis": "^1.23.3",
     "liftoff": "^2.2.1",
     "merge-stream": "^1.0.0",
-    "minimatch": "^3.0.0",
     "minimatch-all": "^1.0.2",
     "multipipe": "^0.3.0",
     "polylint": "^2.10.0",

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -13,7 +13,6 @@ import * as gulp from 'gulp';
 import * as gulpif from 'gulp-if';
 import * as gutil from 'gulp-util';
 import mergeStream = require('merge-stream');
-import * as minimatch from 'minimatch';
 import * as path from 'path';
 import {PassThrough, Readable} from 'stream';
 import File = require('vinyl');

--- a/src/build/optimize.ts
+++ b/src/build/optimize.ts
@@ -9,7 +9,6 @@
  */
 
 import * as gulpif from 'gulp-if';
-import * as minimatch from 'minimatch';
 import * as stream from 'stream';
 
 import {UglifyTransform} from './uglify-transform';

--- a/src/build/stream-resolver.ts
+++ b/src/build/stream-resolver.ts
@@ -10,7 +10,6 @@
 
 import * as fs from 'fs';
 import {Resolver, Deferred, FSResolver} from 'hydrolysis';
-import * as minimatch from 'minimatch';
 import * as path from 'path';
 import {Transform} from 'stream';
 import File = require('vinyl');

--- a/typings.json
+++ b/typings.json
@@ -9,7 +9,6 @@
     "gulp-util": "registry:dt/gulp-util#0.0.0+20160316155526",
     "merge-stream": "registry:dt/merge-stream#1.0.0+20160313224417",
     "mime": "registry:dt/mime#0.0.0+20160316155526",
-    "minimatch": "registry:dt/minimatch#2.0.8+20160317120654",
     "node": "registry:dt/node#4.0.0+20160412142033",
     "serve-static": "registry:dt/serve-static#0.0.0+20160317120654",
     "source-map": "registry:dt/source-map#0.0.0+20160317120654",

--- a/typings.json
+++ b/typings.json
@@ -9,6 +9,7 @@
     "gulp-util": "registry:dt/gulp-util#0.0.0+20160316155526",
     "merge-stream": "registry:dt/merge-stream#1.0.0+20160313224417",
     "mime": "registry:dt/mime#0.0.0+20160316155526",
+    "minimatch": "registry:dt/minimatch#2.0.8+20160317120654",
     "node": "registry:dt/node#4.0.0+20160412142033",
     "serve-static": "registry:dt/serve-static#0.0.0+20160317120654",
     "source-map": "registry:dt/source-map#0.0.0+20160317120654",


### PR DESCRIPTION
We're now using `minimatch-all`